### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Mininet ToyNet
 
+**Note: this repository is no longer actively maintained and its functionality
+has been incorporated into
+[toynet-flask](https://github.com/Project-Reclass/toynet-flask).**
+
+
 This module containerizes and provides interfaces for the backend of ToyNet to
 interface with the Mininet emulator implementing the topology that a user builds.
 


### PR DESCRIPTION
Deprecation notice since we migrated from a toynet submodule to incorporating it into the flask repository. We should also archive this repo.